### PR TITLE
Improve GitHub profile README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,35 +1,43 @@
-![](https://komarev.com/ghpvc/?username=robocnop&color=FD6C9E)
+<div align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&pause=1000&color=FD6C9E&center=true&vCenter=true&width=500&lines=Hey+there!+I'm+Robocnop+%F0%9F%91%8B;Belgian+Developer+%F0%9F%87%A7%F0%9F%87%AA;Open+Source+Contributor+%E2%9C%A8" alt="Typing SVG" />
+</div>
+
+<p align="center">
+  <img src="https://komarev.com/ghpvc/?username=robocnop&color=FD6C9E&style=flat-square" alt="Profile views" />
+</p>
 
 ---
 
 <h2 align="center">👤 About Me 👤</h2>
 <p align="center">
-  Hello! I'm a Belgian 🇧🇪 developer who occasionally works on small projects. I also enjoy translating ReadMe files and Wiki pages for other projects (🇬🇧 -> 🇫🇷).
-  I’ve contributed to several projects, such as UCR and Exiled. My C# plugins can sometimes be a bit messy, but I hope other developers will help and guide me to improve my skills.
+  Hello! I'm a Belgian 🇧🇪 developer who occasionally works on small projects.<br/>
+  I also enjoy translating ReadMe files and Wiki pages for other projects (🇬🇧 → 🇫🇷).<br/>
+  My C# plugins can sometimes be a bit messy, but I hope other developers will help and guide me to improve my skills.
+</p>
 
-  - UCR: (https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles)
-
-  - Exiled: (https://github.com/ExSLMod-Team/EXILED | https://github.com/ExMod-Team/EXILED)
-
-  - AutoEvent: (https://github.com/RisottoMan/AutoEvent)
+<h3 align="center">🚀 Projects I've contributed to</h3>
+<p align="center">
+  <a href="https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles"><strong>UCR</strong> — UncomplicatedCustomRoles</a><br/>
+  <a href="https://github.com/ExMod-Team/EXILED"><strong>EXILED</strong> — Exiled Framework</a><br/>
+  <a href="https://github.com/RisottoMan/AutoEvent"><strong>AutoEvent</strong></a>
 </p>
 
 ---
 
 <h2 align="center">📚 Learning / Using ✍️</h2>
 <p align="center">
-  <code><img title="CSharp" height="40" src="https://github.com/tandpfun/skill-icons/blob/main/icons/CS.svg"></code>
-  <code><img title=".NET" height="40" src="https://github.com/tandpfun/skill-icons/blob/main/icons/DotNet.svg"></code>
-  <code><img title="Lua" height="40" src="https://github.com/Robocnop/skill-icons/blob/main/icons/Lua-Light.svg"></code>
+  <code><img title="C#" height="40" src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/CS.svg" alt="C#"></code>
+  <code><img title=".NET" height="40" src="https://raw.githubusercontent.com/tandpfun/skill-icons/main/icons/DotNet.svg" alt=".NET"></code>
+  <code><img title="Lua" height="40" src="https://raw.githubusercontent.com/Robocnop/skill-icons/main/icons/Lua-Light.svg" alt="Lua"></code>
 </p>
 
 ---
 
 <h2 align="center">🔧 Tools / IDE 🔧</h2>
 <p align="center">
-  <code><img title="Rider" height="40" src="https://github.com/Robocnop/skill-icons/blob/main/icons/Rider-Dark.svg"></code>
-  <code><img title="VSCode" height="40" src="https://github.com/Robocnop/skill-icons/blob/main/icons/VSCode-Dark.svg"></code>
-  <code><img title="Roblox Studio" height="40" src="https://github.com/Robocnop/skill-icons/blob/main/icons/RobloxStudio.svg"></code>
+  <code><img title="Rider" height="40" src="https://raw.githubusercontent.com/Robocnop/skill-icons/main/icons/Rider-Dark.svg" alt="Rider"></code>
+  <code><img title="VSCode" height="40" src="https://raw.githubusercontent.com/Robocnop/skill-icons/main/icons/VSCode-Dark.svg" alt="VSCode"></code>
+  <code><img title="Roblox Studio" height="40" src="https://raw.githubusercontent.com/Robocnop/skill-icons/main/icons/RobloxStudio.svg" alt="Roblox Studio"></code>
 </p>
 
 ---
@@ -38,6 +46,12 @@
 <div align="center">
   <img src="https://github-readme-stats.vercel.app/api?username=Robocnop&show_icons=true&theme=dracula" height="150" alt="Stats Graph">
   <img src="https://github-readme-stats.vercel.app/api/top-langs?username=Robocnop&locale=en&hide_title=false&layout=compact&card_width=320&langs_count=5&theme=dracula&hide_border=false" height="150" alt="Languages Graph">
+</div>
+<br/>
+<div align="center">
   <img src="https://streak-stats.demolab.com?user=Robocnop&locale=en&mode=daily&theme=dracula&hide_border=false&border_radius=5" height="150" alt="Streak Graph">
+</div>
+<br/>
+<div align="center">
   <img src="https://github-readme-activity-graph.vercel.app/graph?username=Robocnop&radius=16&theme=dracula&area=true" height="300" alt="Activity Graph">
 </div>


### PR DESCRIPTION
- Fix skill-icon images: use raw.githubusercontent.com instead of blob URLs so SVG icons actually render
- Make project links clickable (proper <a> tags instead of plain text)
- Add animated typing SVG header for a more engaging first impression
- Separate About Me bio from project contributions for clarity
- Add alt text to all images for accessibility
- Better layout for stats section (less cramped)
- Add .gitignore for OS/editor files

And YEAH claude helped me for that, I wanted to see what he could do and tada he did this (Sorry for the wasted drinkable water & RAM cost lol)